### PR TITLE
Add 'end' method to delete the instance of FspTimer.

### DIFF
--- a/src/AGTimerR4.cpp
+++ b/src/AGTimerR4.cpp
@@ -67,3 +67,7 @@ bool AGTimerR4::start(void) {
 bool AGTimerR4::stop(void) {
   return fsp_timer.stop();
 }
+
+void AGTimerR4::end(void) {
+  fsp_timer.end();
+}

--- a/src/AGTimerR4.h
+++ b/src/AGTimerR4.h
@@ -26,6 +26,7 @@ public:
   void init(int period, timer_source_div_t sd, void (*callback)());
   bool start(void);
   bool stop(void);
+  void end(void);
 };
 
 extern AGTimerR4 AGTimer;


### PR DESCRIPTION
First of all, thank you for the simple and useful library.

I'd like to use this nice library in case of repeating timers with different periods and TIMER_MODE_ONE_SHOT.

The simplest way is to add `AGTimer.end()` to delete `fsp_timer`. I can call `AGTimer.stop()` and `AGTimer.end()` in the callback function, and then call `AGTimer.init()` again.

Alternatively, adding some methods such like `AGTimer.set_period()` may be also good.

I'd appreciate you to consider my request.
Thank you!